### PR TITLE
working area map api endpoint

### DIFF
--- a/src/main/java/report/friction/controllers/ClimbingAreaController.java
+++ b/src/main/java/report/friction/controllers/ClimbingAreaController.java
@@ -5,10 +5,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import report.friction.dto.AreaInitDTO;
-import report.friction.dto.ClimbingAreaDTO;
-import report.friction.dto.ClimbingAreaMapper;
-import report.friction.dto.ClimbingAreaMapperImpl;
+import report.friction.dto.*;
 import report.friction.services.ClimbingAreaService;
 import report.friction.services.ClimbingAreaServiceImpl;
 
@@ -36,11 +33,19 @@ public class ClimbingAreaController {
     }
 
     @GetMapping("/init")
-    public ResponseEntity<List<AreaInitDTO>>getAreasInit(){
+    public ResponseEntity<List<AreaInitDTO>> getAreasInit(){
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-Type", "application/json; charset=utf-8");
         headers.add("Allow", "GET");
         return new ResponseEntity<>(climbingAreaService.getAreasInit(), headers, HttpStatus.OK);
+    }
+
+    @GetMapping("/map")
+    public ResponseEntity<List<AreaMapDTO>> getAreaMapData(){
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json; charset=utf-8");
+        headers.add("Allow", "GET");
+        return new ResponseEntity<>(climbingAreaService.getAreaMapData(), headers, HttpStatus.OK);
     }
 
     @GetMapping("/{areaName}")

--- a/src/main/java/report/friction/dao/ClimbingAreaEntity.java
+++ b/src/main/java/report/friction/dao/ClimbingAreaEntity.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import net.minidev.json.annotate.JsonIgnore;
 import report.friction.dao.weather.*;
@@ -12,6 +13,7 @@ import java.time.Instant;
 import java.util.List;
 
 @Entity
+@EqualsAndHashCode(exclude={"currentWeather","hourlyWeather","dailyWeather", "weatherAlerts"})
 @Data
 @Table(name="climbing_area")
 @NoArgsConstructor

--- a/src/main/java/report/friction/dto/AreaMapDTO.java
+++ b/src/main/java/report/friction/dto/AreaMapDTO.java
@@ -1,0 +1,21 @@
+package report.friction.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import report.friction.dto.weather.CurrentWeatherDTO;
+
+@Data
+public class AreaMapDTO {
+
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("fullName")
+    private String fullName;
+    @JsonProperty("latitude")
+    private Double lat;
+    @JsonProperty("longitude")
+    private Double lon;
+    @JsonProperty("current")
+    private CurrentWeatherDTO currentWeather;
+
+}

--- a/src/main/java/report/friction/dto/ClimbingAreaMapper.java
+++ b/src/main/java/report/friction/dto/ClimbingAreaMapper.java
@@ -41,4 +41,9 @@ public interface ClimbingAreaMapper {
 
     @Mapping(source="areaName", target="name")
     AreaInitDTO climbingAreaEntityToAreaInitDTO(ClimbingAreaEntity climbingArea);
+
+    List<AreaMapDTO> climbingAreaEntityListToAreaMapDTOList(List<ClimbingAreaEntity> climbingAreaEntities);
+
+    @Mapping(source="areaName", target="name")
+    AreaMapDTO climbingAreaEntityToAreaMapDTO(ClimbingAreaEntity climbingArea);
 }

--- a/src/main/java/report/friction/services/ClimbingAreaService.java
+++ b/src/main/java/report/friction/services/ClimbingAreaService.java
@@ -1,6 +1,7 @@
 package report.friction.services;
 
 import report.friction.dto.AreaInitDTO;
+import report.friction.dto.AreaMapDTO;
 import report.friction.dto.ClimbingAreaDTO;
 
 import java.util.List;
@@ -8,6 +9,8 @@ import java.util.List;
 public interface ClimbingAreaService {
 
     public List<AreaInitDTO> getAreasInit();
+
+    public List<AreaMapDTO> getAreaMapData();
 
     public ClimbingAreaDTO getClimbingAreaData(String areaName);
 }


### PR DESCRIPTION
There was a weird issue with climbing area entities and current weather entity hashcode circular references when i was iterating through the list of climbing area entities and updating them. This was solved by excluding current weather from the climbing area entity hashcode calculation